### PR TITLE
Linted upload file

### DIFF
--- a/scripts/upload
+++ b/scripts/upload
@@ -2,24 +2,24 @@
 set -e
 
 # cd to app root
-CWD=$(dirname $0)
-if [ `basename $(pwd)` = 'scripts' ]; then
+CWD=$(dirname "$0")
+if [ "$(basename "$(pwd)")" = 'scripts' ]; then
   cd ../
 else
-  cd `dirname $CWD`
+  cd "$(dirname "$CWD")"
 fi
 
 function exec() {
-  $@
+  "$@"
   if [ $? -ne 0 ]; then
-    echo "Command: $@ failed"
+    echo "Command: $* failed"
     exit 2
   fi
 }
 
-VERSION=$(cat package.json | grep version | cut -f4 -d'"' | sed 's/-/_/g')
+VERSION=$(grep version package.json | cut -f4 -d'"' | sed 's/-/_/g')
 BUILD_DIR="dist/${VERSION}"
 CDN="releases.rancher.com/api-ui"
 
 echo "Uploading..."
-exec gsutil -m cp -R -z "js,css,map" $BUILD_DIR "gs://${CDN}/"
+exec gsutil -m cp -R -z "js,css,map" "$BUILD_DIR" "gs://${CDN}/"


### PR DESCRIPTION
I just did a bit of linting on the shell script and replaced some "problematic" code with some "corrected" code.

The fixes contain the following:

[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) - Double quote to prevent globbing and word splitting.
[SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006) - Use $(..) instead of legacy backticks.
[SC2068](https://github.com/koalaman/shellcheck/wiki/SC2068) - Double quote array expansions to avoid re-splitting elements.
[SC2145](https://github.com/koalaman/shellcheck/wiki/SC2145) - Argument mixes string and array. Use \* or separate argument.
[SC2002](https://github.com/koalaman/shellcheck/wiki/SC2002) - Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.

I didn't see a built in test for this, so if you could please do it manually and let me know if everything works, that would be great.

-Adam
