### PR TITLE
Ensure we upload dist files as well as archive

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,3 +36,18 @@ steps:
   when:
     instance:
       - drone-publish.rancher.io  
+
+- name: upload-files
+  pull: default
+  image: plugins/gcs
+  settings:
+    acl:
+    - allUsers:READER
+    cache_control: "no-cache,must-revalidate"
+    source: dist/${DRONE_TAG##v}
+    target: releases.rancher.com/api-ui/${DRONE_TAG##v}
+    token:
+      from_secret: google_auth_key
+  when:
+    instance:
+      - drone-publish.rancher.io  


### PR DESCRIPTION
Currently we only upload the built archive not the files - these are needed for head builds or builds that reference remote artifacts.